### PR TITLE
refactor: do without `serverBuildEntry` and `@remix-run/dev/server-build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This demo requires `serverBuildEntry` option from this PR https://github.com/rem
 # (see app/miniflare.ts imported by app/entry.server.tsx)
 pnpm dev
 
-# run production build locally with genuine workerd runtime by wrangler dev
-# (see app/adapter-cloudflare-workers.ts)
+# run production build locally with genuine workerd runtime provided by wrangler dev
+# (see app/server.mjs)
 pnpm build
 pnpm preview
 

--- a/app/server.mjs
+++ b/app/server.mjs
@@ -1,10 +1,10 @@
-import * as remixBuild from "@remix-run/dev/server-build";
 import { createRequestHandler } from "@remix-run/server-runtime";
+import * as remixBuild from "../build/index.js";
 
 const remixHandler = createRequestHandler(remixBuild, process.env.NODE_ENV);
 
 export default {
-  async fetch(request: Request, env: unknown, _ctx: unknown) {
+  fetch(request, env, _ctx) {
     Object.assign(globalThis, { env });
     return remixHandler(request);
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,15 +2,7 @@ import { unstable_vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig((env) => ({
+export default defineConfig({
   clearScreen: false,
-  plugins: [
-    remix({
-      serverBuildEntry:
-        env.command === "build"
-          ? "./app/adapter-cloudflare-workers.ts"
-          : undefined,
-    }),
-    tsconfigPaths(),
-  ],
-}));
+  plugins: [remix(), tsconfigPaths()],
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "remix-unstable-vite-cloudflare-workers"
 
-main = "./build/index.js"
+main = "./app/server.mjs"
 assets = "./public"
 workers_dev = true
 node_compat = true


### PR DESCRIPTION
I just realized we don't really need these features to do the same thing...